### PR TITLE
Add Code of Conduct

### DIFF
--- a/conduct.md
+++ b/conduct.md
@@ -44,7 +44,7 @@ When somebody leaves or disengages from the project, we ask that they do so in a
 disruption to the project. They should tell people they are leaving and take the proper steps to
 ensure that others can pick up where they left off.
 
-This Code of Conduct is modified from the [Ubuntu Codes of
-Conduct](https://ubuntu.com/community/governance/code-of-conduct) and is distributed under the
+This Code of Conduct is modified from the [Ubuntu Code of
+Conduct v2.0](https://ubuntu.com/community/governance/code-of-conduct) and is distributed under the
 [Creative Commons Attribution-Share Alike 3.0
 license](http://creativecommons.org/licenses/by-sa/3.0/).

--- a/conduct.md
+++ b/conduct.md
@@ -46,3 +46,8 @@ Members of every project come and go, and daac-tools is no different. When someb
 disengages from the project, in whole or in part, we ask that they do so in a way that minimizes
 disruption to the project. This means they should tell people they are leaving and take the proper
 steps to ensure that others can pick up where they left off.
+
+This Code of Conduct is modified from the [Ubuntu Codes of
+Conduct](https://ubuntu.com/community/governance/code-of-conduct) and is distributed under the
+[Creative Commons Attribution-Share Alike 3.0
+license](http://creativecommons.org/licenses/by-sa/3.0/).

--- a/conduct.md
+++ b/conduct.md
@@ -1,0 +1,48 @@
+daac-tools Code of Conduct
+===============================
+
+Be considerate.
+---------------
+
+Our work will be used by other people, and we in turn will depend on the work of others. Any
+decision we take will affect users and colleagues, and we should take those consequences into
+account when making decisions. Even if it's not obvious at the time, our contributions will impact
+the work of others. For example, changes to code, infrastructure, policy, documentation, and
+translations during a release may negatively impact others' work.
+
+Be respectful.
+--------------
+
+The daac-tools community and members treat one another with respect. Everyone can make a valuable
+contribution to daac-tools. We may not always agree, but disagreement is no excuse for poor
+behavior and poor manners. We might all experience some frustration now and then, but we cannot
+allow that frustration to turn into a personal attack. It's important to remember that a community
+where people feel uncomfortable or threatened is not a productive one. We expect members of the
+daac-tools community to be respectful when dealing with other contributors as well as with people
+outside the daac-tools project.
+
+When we disagree, we consult others.
+------------------------------------
+
+Disagreements, both social and technical, happen all the time, and the daac-tools community is no
+exception. It is important that we resolve disagreements and differing views constructively and
+with the help of the community and community processes. We have places available to facilitate
+discussion, and these places help to decide the right course for daac-tools. When our goals differ
+dramatically, we encourage the creation of alternative projects so that the community can test new
+ideas and contribute to the discussion.
+
+When we are unsure, we ask for help.
+------------------------------------
+
+Nobody knows everything, and nobody is expected to be perfect in the daac-tools community. Asking
+questions avoids many problems down the road, so questions are encouraged. Those who are asked
+questions should be responsive and helpful. However, when asking a question, care must be taken to
+do so in an appropriate forum.
+
+Step down considerately.
+------------------------
+
+Members of every project come and go, and daac-tools is no different. When somebody leaves or
+disengages from the project, in whole or in part, we ask that they do so in a way that minimizes
+disruption to the project. This means they should tell people they are leaving and take the proper
+steps to ensure that others can pick up where they left off.

--- a/conduct.md
+++ b/conduct.md
@@ -1,51 +1,48 @@
 daac-tools Code of Conduct
-===============================
+==========================
 
-Be considerate.
----------------
-
-Our work will be used by other people, and we in turn will depend on the work of others. Any
-decision we take will affect users and colleagues, and we should take those consequences into
-account when making decisions. Even if it's not obvious at the time, our contributions will impact
-the work of others. For example, changes to code, infrastructure, policy, documentation, and
-translations during a release may negatively impact others' work.
-
-Be respectful.
+Be considerate
 --------------
 
-The daac-tools community and members treat one another with respect. Everyone can make a valuable
-contribution to daac-tools. We may not always agree, but disagreement is no excuse for poor
-behavior and poor manners. We might all experience some frustration now and then, but we cannot
-allow that frustration to turn into a personal attack. It's important to remember that a community
-where people feel uncomfortable or threatened is not a productive one. We expect members of the
-daac-tools community to be respectful when dealing with other contributors as well as with people
-outside the daac-tools project.
+Our work will be used by other people, and we in turn will depend on the work of others. Any
+decision we take will affect users and colleagues, and we should consider them when making
+decisions.
 
-When we disagree, we consult others.
-------------------------------------
+Be respectful
+-------------
 
-Disagreements, both social and technical, happen all the time, and the daac-tools community is no
-exception. It is important that we resolve disagreements and differing views constructively and
-with the help of the community and community processes. We have places available to facilitate
-discussion, and these places help to decide the right course for daac-tools. When our goals differ
-dramatically, we encourage the creation of alternative projects so that the community can test new
-ideas and contribute to the discussion.
+Disagreement is no excuse for poor manners. We work together to resolve conflict, assume good
+intentions and do our best to act in an empathic fashion. We don’t allow frustration to turn into
+a personal attack. A community where people feel uncomfortable or threatened is not a productive
+one.
 
-When we are unsure, we ask for help.
-------------------------------------
+Take responsibility for our words and our actions
+-------------------------------------------------
 
-Nobody knows everything, and nobody is expected to be perfect in the daac-tools community. Asking
-questions avoids many problems down the road, so questions are encouraged. Those who are asked
-questions should be responsive and helpful. However, when asking a question, care must be taken to
-do so in an appropriate forum.
+We can all make mistakes; when we do, we take responsibility for them. If someone has been harmed
+or offended, we listen carefully and respectfully, and work to right the wrong.
 
-Step down considerately.
+Value decisiveness, clarity and consensus
+-----------------------------------------
+
+Disagreements, social and technical, are normal, but we do not allow them to persist and fester
+leaving others uncertain of the agreed direction.We expect participants in the project to resolve
+disagreements constructively. When they cannot, we escalate the matter to structures with
+designated leaders to arbitrate and provide clarity and direction.
+
+Ask for help when unsure
 ------------------------
 
-Members of every project come and go, and daac-tools is no different. When somebody leaves or
-disengages from the project, in whole or in part, we ask that they do so in a way that minimizes
-disruption to the project. This means they should tell people they are leaving and take the proper
-steps to ensure that others can pick up where they left off.
+Nobody is expected to be perfect in this community. Asking questions early avoids many problems
+later, so questions are encouraged, though they may be directed to the appropriate forum. Those who
+are asked should be responsive and helpful.
+
+Step down considerately
+-----------------------
+
+When somebody leaves or disengages from the project, we ask that they do so in a way that minimises
+disruption to the project. They should tell people they are leaving and take the proper steps to
+ensure that others can pick up where they left off.
 
 This Code of Conduct is modified from the [Ubuntu Codes of
 Conduct](https://ubuntu.com/community/governance/code-of-conduct) and is distributed under the


### PR DESCRIPTION
This PR adds the Code of Conduct of daac-tools community.
This guideline is modified from the Ubuntu Code of Conduct.